### PR TITLE
Ignore tls-acme fields in routes

### DIFF
--- a/internal/lagoonyml/lagoon.go
+++ b/internal/lagoonyml/lagoon.go
@@ -4,9 +4,6 @@ import "encoding/json"
 
 // Ingress represents a Lagoon route.
 type Ingress struct {
-	TLSACME     string            `json:"tls-acme"`
-	Insecure    string            `json:"insecure"`
-	HSTS        string            `json:"hsts"`
 	Annotations map[string]string `json:"annotations"`
 }
 

--- a/internal/lagoonyml/lint_test.go
+++ b/internal/lagoonyml/lint_test.go
@@ -19,6 +19,14 @@ func TestLint(t *testing.T) {
 			input: "testdata/valid.1.lagoon.yml",
 			valid: true,
 		},
+		"tls-acme boolean": {
+			input: "testdata/valid.2.lagoon.yml",
+			valid: true,
+		},
+		"complete .lagoon.yml": {
+			input: "testdata/valid.3.lagoon.yml",
+			valid: true,
+		},
 		"invalid.0.lagoon.yml": {
 			input: "testdata/invalid.0.lagoon.yml",
 			valid: false,

--- a/internal/lagoonyml/testdata/valid.2.lagoon.yml
+++ b/internal/lagoonyml/testdata/valid.2.lagoon.yml
@@ -1,0 +1,9 @@
+# tls-acme boolean value
+environments:
+  main:
+    monitoring_urls:
+    - "https://www.example.com"
+    routes:
+    - nginx:
+      - "www.example.com":
+          tls-acme: true

--- a/internal/lagoonyml/testdata/valid.3.lagoon.yml
+++ b/internal/lagoonyml/testdata/valid.3.lagoon.yml
@@ -1,0 +1,73 @@
+# more complete valid .lagoon.yml
+docker-compose-yaml: example-docker-compose.yml
+
+tasks:
+  post-rollout:
+    - run:
+        name: Post-rollout script
+        command: /app/scripts/post-rollout.sh
+        service: cli
+
+production_routes:
+  active:
+    routes:
+      - nginx:
+          - "www.example.com":
+              tls-acme: true
+              insecure: Redirect
+          - "de.example.com":
+              tls-acme: "true"
+              insecure: Redirect
+
+  standby:
+    routes:
+      - nginx:
+          - "www.standby.example.com":
+              tls-acme: "false"
+              insecure: Redirect
+          - "de.standby.example.com":
+              tls-acme: "false"
+              insecure: Redirect
+
+routes:
+  autogenerate:
+    prefixes:
+      - www
+      - de
+
+environments:
+  production-green:
+    cronjobs:
+      - name: drush cron
+        schedule: "22 * * * *"
+        command: drush --root=/app/docroot cron
+        service: cli
+  production-blue:
+    cronjobs:
+      - name: drush cron
+        schedule: "22 * * * *"
+        command: drush --root=/app/docroot cron
+        service: cli
+  staging:
+    cronjobs:
+      - name: drush cron
+        schedule: "34 * * * *"
+        command: drush cron
+        service: cli
+    routes:
+      - nginx:
+          - "www.test.example.com":
+              tls-acme: false
+              insecure: Redirect
+          - "de.test.example.com":
+              tls-acme: "false"
+              insecure: Redirect
+  develop:
+    routes:
+      - nginx:
+          - "www.dev.example.com":
+              tls-acme: "false"
+              insecure: Redirect
+          - "de.dev.example.com":
+              tls-acme: false
+              insecure: Redirect


### PR DESCRIPTION
The `tls-acme` field doesn't have any linting policy yet, so don't bother unmarshalling.

Closes: #5 