### PR TITLE
Handle single-quoted annotation arguments

### DIFF
--- a/internal/lagoonyml/lint_test.go
+++ b/internal/lagoonyml/lint_test.go
@@ -31,6 +31,10 @@ func TestLint(t *testing.T) {
 			input: "testdata/valid.4.lagoon.yml",
 			valid: true,
 		},
+		"add_header ... always": {
+			input: "testdata/valid.5.lagoon.yml",
+			valid: true,
+		},
 		"invalid.0.lagoon.yml": {
 			input: "testdata/invalid.0.lagoon.yml",
 			valid: false,

--- a/internal/lagoonyml/lint_test.go
+++ b/internal/lagoonyml/lint_test.go
@@ -27,6 +27,10 @@ func TestLint(t *testing.T) {
 			input: "testdata/valid.3.lagoon.yml",
 			valid: true,
 		},
+		"single quoted arguments": {
+			input: "testdata/valid.4.lagoon.yml",
+			valid: true,
+		},
 		"invalid.0.lagoon.yml": {
 			input: "testdata/invalid.0.lagoon.yml",
 			valid: false,

--- a/internal/lagoonyml/routeannotation.go
+++ b/internal/lagoonyml/routeannotation.go
@@ -18,9 +18,9 @@ const (
 // annotations.
 var validSnippets = regexp.MustCompile(
 	`^(rewrite +[^; ]+ +[^; ]+( (last|break|redirect|permanent))?;|` +
-		`add_header +([^; ]+|"[^"]+")+ +([^; ]+|"[^"]+");|` +
+		`add_header +([^; ]+|"[^"]+"|'[^']+') +([^; ]+|"[^"]+"|'[^']+');|` +
 		`set_real_ip_from +[^; ]+;|` +
-		`more_set_headers +(-s +"[^"]+"|-t +"[^"]+"|"[^"]+")+;|` +
+		`more_set_headers +(-s +("[^"]+"|'[^']+')|-t +("[^"]+"|'[^']+')|("[^"]+"|'[^']+'))+;|` +
 		` )+$`)
 
 // validate returns true if the annotations are valid, and false otherwise.

--- a/internal/lagoonyml/routeannotation.go
+++ b/internal/lagoonyml/routeannotation.go
@@ -18,7 +18,7 @@ const (
 // annotations.
 var validSnippets = regexp.MustCompile(
 	`^(rewrite +[^; ]+ +[^; ]+( (last|break|redirect|permanent))?;|` +
-		`add_header +([^; ]+|"[^"]+"|'[^']+') +([^; ]+|"[^"]+"|'[^']+');|` +
+		`add_header +([^; ]+|"[^"]+"|'[^']+') +([^; ]+|"[^"]+"|'[^']+')( always)?;|` +
 		`set_real_ip_from +[^; ]+;|` +
 		`more_set_headers +(-s +("[^"]+"|'[^']+')|-t +("[^"]+"|'[^']+')|("[^"]+"|'[^']+'))+;|` +
 		` )+$`)

--- a/internal/lagoonyml/testdata/valid.4.lagoon.yml
+++ b/internal/lagoonyml/testdata/valid.4.lagoon.yml
@@ -1,0 +1,21 @@
+environments:
+  main:
+    monitoring_urls:
+    - "https://www.example.com"
+    - "https://www.example.com/special_page"
+    routes:
+    - nginx:
+      - example.com
+      - "www.example.com":
+          tls-acme: 'true'
+          insecure: Redirect
+          hsts: max-age=31536000
+      - "example.com":
+          annotations:
+            nginx.ingress.kubernetes.io/server-snippet: |
+              set_real_ip_from 1.2.3.4/32;
+      - "dev.example.com":
+          annotations:
+            nginx.ingress.kubernetes.io/server-snippet: |
+              set_real_ip_from 1.2.3.4/32;
+              add_header 'Permissions-Policy' 'geolocation=(), microphone=()';

--- a/internal/lagoonyml/testdata/valid.5.lagoon.yml
+++ b/internal/lagoonyml/testdata/valid.5.lagoon.yml
@@ -1,0 +1,9 @@
+environments:
+  main:
+    routes:
+    - nginx:
+      - "dev.example.com":
+          annotations:
+            nginx.ingress.kubernetes.io/server-snippet: |
+              set_real_ip_from 1.2.3.4/32;
+              add_header 'Permissions-Policy' 'geolocation=(), microphone=()' always;


### PR DESCRIPTION
Handle both double and single quotes in nginx snippet annotation arguments.

This PR also adds support for the optional `always` suffix to `add_headers`.