### PR TITLE
Allow real_ip_recursive in nginx.ingress.kubernetes.io/server-snippet

### DIFF
--- a/internal/lagoonyml/routeannotation.go
+++ b/internal/lagoonyml/routeannotation.go
@@ -20,6 +20,7 @@ var validSnippets = regexp.MustCompile(
 	`^(rewrite +[^; ]+ +[^; ]+( (last|break|redirect|permanent))?;|` +
 		`add_header +([^; ]+|"[^"]+"|'[^']+') +([^; ]+|"[^"]+"|'[^']+')( always)?;|` +
 		`set_real_ip_from +[^; ]+;|` +
+		`real_ip_recursive o(n|ff);|` +
 		`more_set_headers +(-s +("[^"]+"|'[^']+')|-t +("[^"]+"|'[^']+')|("[^"]+"|'[^']+'))+;|` +
 		` )+$`)
 

--- a/internal/lagoonyml/routeannotation_test.go
+++ b/internal/lagoonyml/routeannotation_test.go
@@ -57,6 +57,14 @@ func TestServerSnippet(t *testing.T) {
 			input: "set_real_ip_from 128.128.128.128;\nif (true) { return 301 http://example.com;\n};\n",
 			valid: false,
 		},
+		"valid real_ip_recursive": {
+			input: "real_ip_recursive on;\n",
+			valid: true,
+		},
+		"invalid real_ip_recursive": {
+			input: "real_ip_recursive foo;\n",
+			valid: false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(tt *testing.T) {

--- a/internal/lagoonyml/testdata/invalid.0.lagoon.yml
+++ b/internal/lagoonyml/testdata/invalid.0.lagoon.yml
@@ -16,3 +16,7 @@ environments:
               if ($request_uri !~ \"^/abc\") {
                 return 301 https://dev.example.com$request_uri;
               }
+      - "dev.example.com":
+          annotations:
+            nginx.ingress.kubernetes.io/server-snippet: |
+              real_ip_recursive  on;

--- a/internal/lagoonyml/testdata/valid.0.lagoon.yml
+++ b/internal/lagoonyml/testdata/valid.0.lagoon.yml
@@ -14,8 +14,10 @@ environments:
           annotations:
             nginx.ingress.kubernetes.io/server-snippet: |
               set_real_ip_from 1.2.3.4/32;
+              real_ip_recursive on;
       - "dev.example.com":
           annotations:
             nginx.ingress.kubernetes.io/server-snippet: |
+              real_ip_recursive off;
               set_real_ip_from 1.2.3.4/32;
               add_header Content-type text/plain;


### PR DESCRIPTION
See [nginx docs](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive) for more information on this setting. Basically it causes nginx to recursively resolve the real IP while respecting the `set_real_ip_from` ips. I plan to also add support for `real_ip_header` tomorrow in a separate pull.

This change will require some modifications to the docs as well as updates to the `kubectl-build-deploy-dind` container. 
Check out the original PR adding this verification to the KBD container: https://github.com/uselagoon/lagoon/pull/2889