### PR TITLE
feat: fail validation for multiline cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First get a dump of configmaps:
 ```
 for cluster in abc1 xyz2; do
   # assuming kconfig switches kubectl contexts
-  kconfig myname-$cluster && kubectl get configmap -Ao json > ~/download/lagoon-yml-audit/amazeeio-$cluster.cm.json;
+  kconfig myname-$cluster && kubectl get configmap --field-selector metadata.name=lagoon-yaml -Ao json > ~/download/lagoon-yml-audit/amazeeio-$cluster.cm.json;
 done
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently implemented linters.
 | Name            | Profile    | Description                                                                                                                                                                 |
 | ---             | ---        | ---                                                                                                                                                                         |
 | RouteAnnotation | required   | Validates Lagoon Route / Kubernetes Ingress annotations. See the documentation [here](https://docs.lagoon.sh/using-lagoon-the-basics/lagoon-yml/#restrictions) for details. |
+| Cronjobs        | required   | Validates environment cron jobs. |
 | MonitoringURLs  | deprecated | Checks for the presence of `monitoring_urls`.                                                                                                                               |
 
 ## Usage

--- a/cmd/lagoon-linter/validateconfigmapjson.go
+++ b/cmd/lagoon-linter/validateconfigmapjson.go
@@ -40,19 +40,21 @@ func (cmd *ValidateConfigMapJSONCmd) Run() error {
 	}
 	// lint it
 	for _, cm := range cml.ConfigMaps {
-		if cm.Metadata["name"] == "lagoon-yaml" {
-			if lagoonYAML, ok := cm.Data["post-deploy"]; ok {
-				switch cmd.Profile {
-				case "required":
-					err = required.Lint([]byte(lagoonYAML), required.DefaultLinters())
-				case "deprecated":
-					err = deprecated.Lint([]byte(lagoonYAML), deprecated.DefaultLinters())
-				default:
-					return fmt.Errorf("invalid profile: %v", cmd.Profile)
-				}
-				if err != nil {
-					fmt.Printf("bad .lagoon.yml: %s: %v\n", cm.Metadata["namespace"], err)
-				}
+		if cm.Metadata["name"] != "lagoon-yaml" {
+			continue
+		}
+
+		if lagoonYAML, ok := cm.Data["post-deploy"]; ok {
+			switch cmd.Profile {
+			case "required":
+				err = required.Lint([]byte(lagoonYAML), required.DefaultLinters())
+			case "deprecated":
+				err = deprecated.Lint([]byte(lagoonYAML), deprecated.DefaultLinters())
+			default:
+				return fmt.Errorf("invalid profile: %v", cmd.Profile)
+			}
+			if err != nil {
+				fmt.Printf("bad .lagoon.yml: %s: %v\n", cm.Metadata["namespace"], err)
 			}
 		}
 	}

--- a/cmd/lagoon-linter/validateconfigmapjson.go
+++ b/cmd/lagoon-linter/validateconfigmapjson.go
@@ -40,17 +40,19 @@ func (cmd *ValidateConfigMapJSONCmd) Run() error {
 	}
 	// lint it
 	for _, cm := range cml.ConfigMaps {
-		if lagoonYAML, ok := cm.Data[".lagoon.yml"]; ok {
-			switch cmd.Profile {
-			case "required":
-				err = required.Lint([]byte(lagoonYAML), required.DefaultLinters())
-			case "deprecated":
-				err = deprecated.Lint([]byte(lagoonYAML), deprecated.DefaultLinters())
-			default:
-				return fmt.Errorf("invalid profile: %v", cmd.Profile)
-			}
-			if err != nil {
-				fmt.Printf("bad .lagoon.yml: %s: %v\n", cm.Metadata["namespace"], err)
+		if cm.Metadata["name"] == "lagoon-yaml" {
+			if lagoonYAML, ok := cm.Data["post-deploy"]; ok {
+				switch cmd.Profile {
+				case "required":
+					err = required.Lint([]byte(lagoonYAML), required.DefaultLinters())
+				case "deprecated":
+					err = deprecated.Lint([]byte(lagoonYAML), deprecated.DefaultLinters())
+				default:
+					return fmt.Errorf("invalid profile: %v", cmd.Profile)
+				}
+				if err != nil {
+					fmt.Printf("bad .lagoon.yml: %s: %v\n", cm.Metadata["namespace"], err)
+				}
 			}
 		}
 	}

--- a/internal/lagoonyml/required/cronjobs.go
+++ b/internal/lagoonyml/required/cronjobs.go
@@ -9,7 +9,7 @@ import (
 // newlines, and nil otherwise.
 func ValidateCronjob(c *LagoonCronjob) error {
 	if strings.Contains(strings.TrimSpace(c.Command), "\n") {
-		return fmt.Errorf("%q",
+		return fmt.Errorf("invalid cronjob, multiline commands are not supported: %q",
 			c.Command)
 	}
 

--- a/internal/lagoonyml/required/cronjobs.go
+++ b/internal/lagoonyml/required/cronjobs.go
@@ -1,0 +1,30 @@
+package required
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateCronjob returns an error if the command for the cronjob has any
+// newlines, and nil otherwise.
+func ValidateCronjob(c *LagoonCronjob) error {
+	if strings.Contains(strings.TrimSpace(c.Command), "\n") {
+		return fmt.Errorf("%q",
+			c.Command)
+	}
+
+	return nil
+}
+
+// Cronjobs checks for valid environment cronjobs.
+func Cronjobs(l *Lagoon) error {
+	for eName, e := range l.Environments {
+		for _, lagoonCronjob := range e.Cronjobs {
+			if err := ValidateCronjob(&lagoonCronjob); err != nil {
+				return fmt.Errorf("environment %s: %v", eName, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/lagoonyml/required/cronjobs_test.go
+++ b/internal/lagoonyml/required/cronjobs_test.go
@@ -1,0 +1,150 @@
+package required_test
+
+import (
+	"testing"
+
+	"github.com/uselagoon/lagoon-linter/internal/lagoonyml/required"
+	"sigs.k8s.io/yaml"
+)
+
+// All the possible YAML incantations for introducing a newline into a string.
+// https://yaml-multiline.info/
+var multiline = `environments:
+  main:
+    cronjobs:
+      - name: flow scalar plain
+        command: multiline
+
+          command
+      - name: flow scalar single quoted
+        command: 'multiline
+
+          command'
+      - name: flow scalar double quoted newline
+        command: "multiline
+
+          command"
+      - name: flow scalar double quoted escaped
+        command: "multiline\ncommand"
+      - name: multiline block literal clipped
+        command: |
+          multiline
+          command
+
+      - name: block scalar literal stripped
+        command: |-
+          multiline
+          command
+
+      - name: block scalar literal keep
+        command: |+
+          multiline
+          command
+
+      - name: block scalar folded clipped
+        command: >
+          multiline
+
+          command
+
+      - name: block scalar folded stripped
+        command: >-
+          multiline
+
+          command
+
+      - name: block scalar folded keep
+        command: >+
+          multiline
+
+          command
+
+`
+
+// Strings that may appear to have newlines but don't.
+var singleline = `environments:
+  main:
+    cronjobs:
+      - name: flow scalar plain 1
+        command: singleline
+          command
+      - name: flow scalar plain 2
+        command: singleline command
+      - name: flow scalar plain 3
+        command: singleline\ncommand
+      - name: flow scalar single quoted 1
+        command: 'singleline
+          command'
+      - name: flow scalar single quoted 2
+        command: 'singleline command'
+      - name: flow scalar single quoted 3
+        command: 'singleline\ncommand'
+      - name: flow scalar double quoted 1
+        command: "singleline
+          command"
+      - name: flow scalar double quoted 2
+        command: "singleline command"
+      - name: flow scalar double quoted 3
+        command: "singleline\
+          command"
+      - name: block scalar literal stripped
+        command: |-
+          singleline command
+
+      - name: block scalar folded clipped 1
+        command: >
+          singleline
+          command
+      - name: block scalar folded clipped 2
+        command: >
+          singleline command
+      - name: block scalar folded stripped 1
+        command: >-
+          singleline
+          command
+      - name: block scalar folded stripped 2
+        command: >-
+          singleline command
+
+`
+
+func TestMultilineCommand(t *testing.T) {
+	var l required.Lagoon
+	if err := yaml.Unmarshal([]byte(multiline), &l); err != nil {
+		t.Fatalf("couldn't unmarshal YAML: %v", err)
+	}
+
+	for _, e := range l.Environments {
+		for _, lagoonCronjob := range e.Cronjobs {
+			t.Run(lagoonCronjob.Name, func(tt *testing.T) {
+				err := required.ValidateCronjob(&lagoonCronjob)
+
+				tt.Log(err)
+				if err == nil {
+					tt.Fatalf("expected error, but got nil")
+				}
+			})
+		}
+	}
+
+}
+
+func TestSinglelineCommand(t *testing.T) {
+	var l required.Lagoon
+	if err := yaml.Unmarshal([]byte(singleline), &l); err != nil {
+		t.Fatalf("couldn't unmarshal YAML: %v", err)
+	}
+
+	for _, e := range l.Environments {
+		for _, lagoonCronjob := range e.Cronjobs {
+			t.Run(lagoonCronjob.Name, func(tt *testing.T) {
+				err := required.ValidateCronjob(&lagoonCronjob)
+
+				if err != nil {
+					tt.Fatalf("unexpected error %v", err)
+				}
+			})
+		}
+	}
+
+}

--- a/internal/lagoonyml/required/lagoon.go
+++ b/internal/lagoonyml/required/lagoon.go
@@ -14,17 +14,18 @@ type LagoonRoute struct {
 	Ingresses map[string]Ingress
 }
 
-type LagoonCronjob struct {
-	Name    string
-	Command string
-}
-
 // UnmarshalJSON implements json.Unmarshaler.
 func (lr *LagoonRoute) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &lr.Name); err == nil {
 		return nil
 	}
 	return json.Unmarshal(data, &lr.Ingresses)
+}
+
+// LagoonCronjob represents a Lagoon cronjob.
+type LagoonCronjob struct {
+	Name    string `json:"name"`
+	Command string `json:"command"`
 }
 
 // Environment represents a Lagoon environment.

--- a/internal/lagoonyml/required/lagoon.go
+++ b/internal/lagoonyml/required/lagoon.go
@@ -14,6 +14,11 @@ type LagoonRoute struct {
 	Ingresses map[string]Ingress
 }
 
+type LagoonCronjob struct {
+	Name    string
+	Command string
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (lr *LagoonRoute) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &lr.Name); err == nil {
@@ -24,7 +29,8 @@ func (lr *LagoonRoute) UnmarshalJSON(data []byte) error {
 
 // Environment represents a Lagoon environment.
 type Environment struct {
-	Routes []map[string][]LagoonRoute `json:"routes"`
+	Routes   []map[string][]LagoonRoute `json:"routes"`
+	Cronjobs []LagoonCronjob            `json:"cronjobs"`
 }
 
 // ProductionRoutes represents an active/standby configuration.

--- a/internal/lagoonyml/required/lint.go
+++ b/internal/lagoonyml/required/lint.go
@@ -12,7 +12,7 @@ type Linter func(*Lagoon) error
 
 // DefaultLinters returns the list of default linters for this profile.
 func DefaultLinters() []Linter {
-	return []Linter{RouteAnnotation}
+	return []Linter{RouteAnnotation, Cronjobs}
 }
 
 // Lint takes a byte slice containing raw YAML and applies `.lagoon.yml` lint

--- a/internal/lagoonyml/required/lint_test.go
+++ b/internal/lagoonyml/required/lint_test.go
@@ -64,6 +64,10 @@ func TestLint(t *testing.T) {
 			input: "testdata/invalid.5.lagoon.yml",
 			valid: false,
 		},
+		"multiline cronjobs": {
+			input: "testdata/invalid.6.lagoon.yml",
+			valid: false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(tt *testing.T) {

--- a/internal/lagoonyml/required/testdata/invalid.6.lagoon.yml
+++ b/internal/lagoonyml/required/testdata/invalid.6.lagoon.yml
@@ -1,0 +1,13 @@
+environments:
+  main:
+    cronjobs:
+      - name: multiline cron command
+        schedule: "15 1 * * *"
+        command: |-
+            echo "multiline \
+            cron command"
+        service: cli
+      - name: Some nightly task
+        schedule: '5 2 * * *'
+        command: |
+          /app/scripts/custom_task.sh

--- a/internal/lagoonyml/required/testdata/valid.3.lagoon.yml
+++ b/internal/lagoonyml/required/testdata/valid.3.lagoon.yml
@@ -46,7 +46,8 @@ environments:
     cronjobs:
       - name: drush cron
         schedule: "22 * * * *"
-        command: drush --root=/app/docroot cron
+        command: >-
+          drush --root=/app/docroot cron
         service: cli
   staging:
     cronjobs:


### PR DESCRIPTION
Part of https://github.com/uselagoon/build-deploy-tool/issues/103.

The way YAML handles strings allows users to configure cron jobs with multiline commands. As detailed in the above issue, this can cause issues during builds. In addition to calling this out in the docs, this PR also adds a failing lint for this scenario.

I've added tests for all the multiline scenarios outlined at https://yaml-multiline.info/.